### PR TITLE
Add retry mechanism to `fetch_text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix gender value mix character cases.
+- Fix `fetch_text()` by adding retry ability with exponential backoff. [#85]
+
 ## [[1.5.0]] - 2019-03-19
 
 ### Fixed
@@ -108,3 +113,4 @@ This first version allows a user to retrieve traffic fatality repports for a cer
 [#61]: https://github.com/scrapd/scrapd/pull/61
 [#64]: https://github.com/scrapd/scrapd/pull/64
 [#66]: https://github.com/scrapd/scrapd/pull/66
+[#85]: https://github.com/scrapd/scrapd/pull/85

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ loguru==0.2.4
 lxml==4.3.0
 pbr==5.1.1
 tabulate==0.8.2
+tenacity==5.0.4
 
 # TODO(remyg): These libraries are deprecated. Use a modern authentication method and remove them.
 oauth2client


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

Sometimes the `fetch_text` function does not succeed to retrieve data
and makes ScrAPD crash. This patch adds a retry mechanism to this
function, with exponential backoff, and simply raises a `ValueError`
exception if it really cannot retrieve any data.


<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes scrapd/scrapd#83