### PR TITLE
Parse more deceased field formats

### DIFF
--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -238,22 +238,69 @@ def test_extract_traffic_fatalities_page_details_link_00(news_page):
 
 @pytest.mark.parametrize('deceased,expected', (
     ("Rosbel “Rudy” Tamez, Hispanic male (D.O.B. 10-10-54)", {
+        Fields.FIRST_NAME: "Rosbel",
         Fields.LAST_NAME: "Tamez",
-        Fields.FIRST_NAME: "Rosbel"
+        Fields.ETHNICITY: "Hispanic",
+        Fields.GENDER: "male",
+        Fields.DOB: '10/10/1954',
     }),
     ("Eva Marie Gonzales, W/F, DOB: 01-22-1961 (passenger)", {
-        Fields.LAST_NAME: "Gonzales",
         Fields.FIRST_NAME: "Eva",
-        Fields.GENDER: 'f'
+        Fields.LAST_NAME: "Gonzales",
+        Fields.ETHNICITY: "White",
+        Fields.GENDER: 'female',
+        Fields.DOB: '01/22/1961',
     }),
     (
         'DOB: 01-01-99',
         {
-            Fields.DOB: '01-01-99',
+            Fields.DOB: '01/01/1999',
+        },
+    ),
+    (
+        'Wing Cheung Chou | Asian male | 08/01/1949',
+        {
+            Fields.FIRST_NAME: "Wing",
+            Fields.LAST_NAME: "Chou",
+            Fields.ETHNICITY: "Asian",
+            Fields.GENDER: "male",
+            Fields.DOB: '08/01/1949',
+        },
+    ),
+    (
+        'Christopher M Peterson W/M 10-8-1981',
+        {
+            Fields.FIRST_NAME: "Christopher",
+            Fields.LAST_NAME: "Peterson",
+            Fields.ETHNICITY: "White",
+            Fields.GENDER: "male",
+            Fields.DOB: '10/08/1981',
+        },
+    ),
+    (
+        'Luis Angel Tinoco, Hispanic male (11-12-07',
+        {
+            Fields.FIRST_NAME: "Luis",
+            Fields.LAST_NAME: "Tinoco",
+            Fields.ETHNICITY: "Hispanic",
+            Fields.GENDER: "male",
+            Fields.DOB: '11/12/2007'
+        },
+    ),
+    (
+        'Ronnie Lee Hall, White male, 8-28-51',
+        {
+            Fields.FIRST_NAME: "Ronnie",
+            Fields.LAST_NAME: "Hall",
+            Fields.ETHNICITY: "White",
+            Fields.GENDER: "male",
+            Fields.DOB: '08/28/1951'
         },
     ),
 ))
-def test_parse_deceased_field(deceased, expected):
+def test_parse_deceased_field_00(deceased, expected):
+    """Ensure a deceased field is parsed correctly."""
+    d = {}
     d = apd.parse_deceased_field(deceased)
     for key in expected:
         assert d[key] == expected[key]
@@ -339,6 +386,14 @@ def test_parse_page_content_00(filename, expected):
     if 'Notes' in actual and 'Notes' not in expected:
         del actual['Notes']
     assert actual == expected
+
+
+def test_parse_page_content_01(mocker):
+    """Ensure a `parse_deceased_field` exception is caught and does not propagate."""
+    page_fd = TEST_DATA_DIR / 'traffic-fatality-2-3'
+    page = page_fd.read_text()
+    mocker.patch('scrapd.core.apd.parse_deceased_field', side_effect=ValueError)
+    apd.parse_page_content(page)
 
 
 @pytest.mark.parametrize('filename,expected', [(k, v) for k, v in parse_twitter_fields_scenarios.items()])

--- a/tests/core/test_date_utils.py
+++ b/tests/core/test_date_utils.py
@@ -29,10 +29,20 @@ def test_parse_date_01():
         date_utils.parse_date('Not a date')
 
 
-@pytest.mark.parametrize('date, expected', [
-    ('Jan 10 2019', '01/10/2019'),
-    ('2019-01-10', '01/10/2019'),
+@pytest.mark.parametrize('date, dob, expected', [
+    ('Jan 10 2019', False, '01/10/2019'),
+    ('2019-01-10', False, '01/10/2019'),
+    ('10-10-54', True, '10/10/1954'),
 ])
-def test_clean_date_string_00(date, expected):
+def test_clean_date_string_00(date, dob, expected):
     """Ensure date string is properly formatted."""
-    assert date_utils.clean_date_string(date) == expected
+    assert date_utils.clean_date_string(date, dob) == expected
+
+
+@pytest.mark.parametrize('date, expected', [
+    (datetime.datetime(2019, 1, 10, 0, 0), datetime.datetime(2019, 1, 10, 0, 0)),
+    (datetime.datetime(2054, 10, 10, 0, 0), datetime.datetime(1954, 10, 10, 0, 0)),
+])
+def test_check_dob_00(date, expected):
+    """Ensure a DOB is valid."""
+    assert date_utils.check_dob(date) == expected


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)
- Code cleanup / Refactoring

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->
Parse more deceased field formats

Enhances the parsers to be able to extract information from more formats
of the deceased fields.

It now handles the fields separated by:
* pipes
* spaces

It also fixes the case when multiple fatalities occurred in one crash by
picking up the details of the first victim.

Other improvements:
* Create new function for parsing the FLEG.
* Improve the `Gender` parsing.
* Improve the `Ethnicity` parsing.



<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [X] I have updated the documentation accordingly
-  [X] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes scrapd/scrapd#80
Fixes scrapd/scrapd#77
Fixes scrapd/scrapd#51