### PR TITLE
Extract crashes number parsing into its own function

### DIFF
--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -452,8 +452,6 @@ def parse_page_content(detail_page, notes_parsed=False):
     """
     d = {}
     searches = [
-        (Fields.CASE, re.compile(r'Case:.*\s(?:</strong>)?([0-9\-]+)<')),
-        (Fields.CRASHES, re.compile(r'Traffic Fatality #(\d{1,3})')),
         (Fields.DATE, re.compile(r'>Date:.*\s{2,}(?:</strong>)?([^<]*)</')),
         (Fields.DECEASED, re.compile(r'>Deceased:\s*(?:</span>)?(?:</strong>)?\s*>?([^<]*\d)\s*.*\)?<')),
         (Fields.LOCATION, re.compile(r'>Location:.*>\s{2,}(?:</strong>)?([^<]+)')),
@@ -467,6 +465,9 @@ def parse_page_content(detail_page, notes_parsed=False):
 
     # Parse the `Case` field.
     d[Fields.CASE] = parse_case_field(normalized_detail_page)
+
+    # Parse the `Crashes` field.
+    d[Fields.CRASHES] = parse_crashes_field(normalized_detail_page)
 
     # Parse the `Deceased` field.
     if d.get(Fields.DECEASED):
@@ -510,8 +511,33 @@ def parse_case_field(page):
         ''',
         re.VERBOSE,
     )
-    match = re.search(case_pattern, page)
-    return match.groups()[0] if match else ''
+    return match_pattern(page, case_pattern)
+
+
+def parse_crashes_field(page):
+    """
+    Extract the crash number from the content of the fatality page.
+
+    :param str page: the content of the fatality page
+    :return: a string representing the crash number.
+    :rtype: str
+    """
+    crashes_pattern = re.compile(r'Traffic Fatality #(\d{1,3})')
+    return match_pattern(page, crashes_pattern)
+
+
+def match_pattern(text, pattern, group_number=0):
+    """
+    Match a pattern.
+
+    :param str text: the text to match the pattern against
+    :param compiled regex pattern: the pattern to look for
+    :param int group_number: the capturing group number
+    :return: a string representing the captured group.
+    :rtype: str
+    """
+    match = re.search(pattern, text)
+    return match.groups()[group_number] if match else ''
 
 
 def parse_twitter_fields(page):

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -489,4 +489,12 @@ async def test_async_retrieve_00(fake_news):
 def test_parse_case_field_00(input_, expected):
     """Ensure a case field gets parsed correctly."""
     actual = apd.parse_case_field(input_)
+
+
+@pytest.mark.parametrize(
+    'input_, expected',
+    (('<span property="dc:title" content="Traffic Fatality #12" class="rdf-meta element-hidden"></span>', '12'), ))
+def test_parse_crashes_field_00(input_, expected):
+    """Ensure the crashes field gets parsed correctly."""
+    actual = apd.parse_crashes_field(input_)
     assert actual == expected


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- New feature (non-breaking change which adds functionality)
- Code cleanup / Refactoring
- Documentation

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

In order to increase the code readability and ease the maintenance, this
patch extract the functionality parsing the case number into its own
function parse_crashes_field.


<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Partial work for scrapd/scrapd#98
Fixes scrapd/scrapd#104