### PR TITLE
Parse time containing words and extract to its own function

### DIFF
--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -464,7 +464,6 @@ def parse_page_content(detail_page, notes_parsed=False):
         (Fields.DATE, re.compile(r'>Date:.*\s{2,}(?:</strong>)?([^<]*)</')),
         (Fields.DECEASED, re.compile(r'>Deceased:\s*(?:</span>)?(?:</strong>)?\s*>?([^<]*\d)\s*.*\)?<')),
         (Fields.LOCATION, re.compile(r'>Location:.*>\s{2,}(?:</strong>)?([^<]+)')),
-        (Fields.TIME, re.compile(r'>Time:.*>\s{2,}(?:</strong>)?([^<]+)')),
     ]
     normalized_detail_page = unicodedata.normalize("NFKD", detail_page)
     for search in searches:
@@ -479,6 +478,9 @@ def parse_page_content(detail_page, notes_parsed=False):
 
     # Parse the `Crashes` field.
     d[Fields.CRASHES] = parse_crashes_field(normalized_detail_page)
+
+    # Parse the `Time` field.
+    d[Fields.TIME] = parse_time_field(normalized_detail_page)
 
     # Parse the `Deceased` field.
     if d.get(Fields.DECEASED):
@@ -539,16 +541,18 @@ def parse_time_field(page):
     Extract the time from the content of the fatality page.
 
     :param str page: the content of the fatality page
-    :return: a string representing the case number.
+    :return: a string representing the time.
     :rtype: str
     """
     time_pattern = re.compile(
         r'''
-        Time:           # The name of the desired field.
-        .*?             # Any character (lazy).
-        (\d{1,2}:\d{2}  # Time format (##:## or #:##).
-        \s*             # Any whitespace.
-        [AaPp]\.[Mm]\.) # a.m./p.m. (upper or lower).
+        Time:                             # The name of the desired field.
+        \D*?                              # Any non-digit character (lazy).
+        ((?:0?[1-9]|1[0-2]):[0-5]\d       # 12h format.
+        \s*                               # Any whitespace (zero-unlimited).
+        [AaPp]\.?[Mm]\.?                  # AM/PM variations.
+        |                                 # OR
+        (?:[01]?[0-9]|2[0-3]):[0-5][0-9]) # 24h format.
         ''',
         re.VERBOSE,
     )

--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -534,6 +534,27 @@ def parse_crashes_field(page):
     return match_pattern(page, crashes_pattern)
 
 
+def parse_time_field(page):
+    """
+    Extract the time from the content of the fatality page.
+
+    :param str page: the content of the fatality page
+    :return: a string representing the case number.
+    :rtype: str
+    """
+    time_pattern = re.compile(
+        r'''
+        Time:           # The name of the desired field.
+        .*?             # Any character (lazy).
+        (\d{1,2}:\d{2}  # Time format (##:## or #:##).
+        \s*             # Any whitespace.
+        [AaPp]\.[Mm]\.) # a.m./p.m. (upper or lower).
+        ''',
+        re.VERBOSE,
+    )
+    return match_pattern(page, time_pattern)
+
+
 def match_pattern(text, pattern, group_number=0):
     """
     Match a pattern.

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -610,9 +610,19 @@ def test_extract_twitter_description_meta_00(input_, expected):
 
 
 @pytest.mark.parametrize('input_,expected', (
-    ('Time:</span></strong>            Approximately 8:40 p.m.<br />', '8:40 p.m.'),
-    ('<strong>Time:</strong>            1:38 p.m.', '1:38 p.m.'),
-    ('Time:</strong>         Approx 11:40 A.M..<br />', '11:40 A.M.'),
+    ('Time: </span>   Approximately 01:14a.m.', '01:14a.m.'),
+    ('<tag>Time:     08:35 pm<br />', '08:35 pm'),
+    ('Time:  8:47  P.M.', '8:47  P.M.'),
+    ('Time:12:47 p.M.', '12:47 p.M.'),
+    ('Time: 5:16', '5:16'),
+    ('Time: 05:16 ', '05:16'),
+    ('Time: 18:26', '18:26'),
+    ('Time: 22:56', '22:56'),
+    ('Time: 54:34', ''),
+    ('Time: 28:24', ''),
+    ('Time: 4:66 pm', ''),
+    ('Time: 18:46 pm', '18:46'),
+    ('Time: 00:24 a.m.', '00:24'),
 ))
 def test_parse_time_field_00(input_, expected):
     """Ensure a time field gets parsed correctly."""

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -530,6 +530,7 @@ async def test_async_retrieve_00(fake_news):
 def test_parse_case_field_00(input_, expected):
     """Ensure a case field gets parsed correctly."""
     actual = apd.parse_case_field(input_)
+    assert actual == expected
 
 
 @pytest.mark.parametrize(
@@ -605,4 +606,15 @@ def test_extract_twitter_tittle_meta_00(input_, expected):
 def test_extract_twitter_description_meta_00(input_, expected):
     """Ensure we can extract the twitter tittle from the meta tag."""
     actual = apd.extract_twitter_description_meta(input_)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('input_,expected', (
+    ('Time:</span></strong>            Approximately 8:40 p.m.<br />', '8:40 p.m.'),
+    ('<strong>Time:</strong>            1:38 p.m.', '1:38 p.m.'),
+    ('Time:</strong>         Approx 11:40 A.M..<br />', '11:40 A.M.'),
+))
+def test_parse_time_field_00(input_, expected):
+    """Ensure a time field gets parsed correctly."""
+    actual = apd.parse_time_field(input_)
     assert actual == expected


### PR DESCRIPTION


Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)


Description
-----------
The time parser now has its own function and associated test.
The regex will handle words in the time field before the time,
and will capture upper- and lowercase a.m./p.m.



<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [x] I have updated the documentation accordingly
-  [x] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes: scrapd/scrapd#119 and #107 
