### PR TITLE
Resolving the method argument error.

### DIFF
--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -260,12 +260,12 @@ def sanitize_fatality_entity(d):
     :rtype: dict
     """
     # All values must be strings.
-    print('chandu')
     for k, v in d.items():
-        print('chandu')
         print(type(v))
-        # if not v.strip():
-        #     continue
+        if isinstance(v, str):
+            if not v.strip():
+                continue
+        
         if isinstance(v, list):
             d[k] = ' '.join(v)
 

--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -260,7 +260,12 @@ def sanitize_fatality_entity(d):
     :rtype: dict
     """
     # All values must be strings.
+    print('chandu')
     for k, v in d.items():
+        print('chandu')
+        print(type(v))
+        # if not v.strip():
+        #     continue
         if isinstance(v, list):
             d[k] = ' '.join(v)
 

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -608,10 +608,13 @@ def test_extract_twitter_description_meta_00(input_, expected):
     assert actual == expected
 
 
-@pytest.mark.parametrize('input_,expected', (
-    ({
-        "Time": " ",
-    }, {},),
+@pytest.mark.parametrize('input_', (
+    (
+        {
+            "Time": " ",
+        },
+        {},
+    ),
     (
         {
             "Time": 345
@@ -630,8 +633,8 @@ def test_extract_twitter_description_meta_00(input_, expected):
         },
         {},
     ),
-))
+) )
 def test_sanitize_fatality_entity(input_, expected):
     """Ensure."""
-    actual = apd.sanitize_fatality_entity(input_, expected)
+    actual = apd.sanitize_fatality_entity(input_)
     assert actual == expected

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -634,7 +634,7 @@ def test_extract_twitter_description_meta_00(input_, expected):
         {},
     ),
 ) )
-def test_sanitize_fatality_entity(input_, expected):
+def test_sanitize_fatality_entity(input_):
     """Ensure."""
     actual = apd.sanitize_fatality_entity(input_)
-    assert actual == expected
+    assert actual == ''

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -606,3 +606,32 @@ def test_extract_twitter_description_meta_00(input_, expected):
     """Ensure we can extract the twitter tittle from the meta tag."""
     actual = apd.extract_twitter_description_meta(input_)
     assert actual == expected
+
+
+@pytest.mark.parametrize('input_,expected', (
+    ({
+        "Time": " ",
+    }, {},),
+    (
+        {
+            "Time": 345
+        },
+        {},
+    ),
+    (
+        {
+            "Time": ['123', '345']
+        },
+        {},
+    ),
+    (
+        {
+            "Time": None
+        },
+        {},
+    ),
+))
+def test_sanitize_fatality_entity(input_, expected):
+    """Ensure."""
+    actual = apd.sanitize_fatality_entity(input_, expected)
+    assert actual == expected


### PR DESCRIPTION
Remy, Getting below error while doing 'make test-units'

actual = apd.sanitize_fatality_entity(input_, expected)
E       TypeError: sanitize_fatality_entity() takes 1 positional argument but 2 were given

tests/core/test_apd.py:636: TypeError


!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! xdist.dsession.Interrupted: stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================== 1 failed, 52 passed, 4 warnings in 6.45 seconds ==============================================================
ERROR: InvocationError for command /Users/cvenigalla/projects/scrapd/.tox/py37/bin/pytest -x --junitxml=/tmp/pytest/junit-py37.xml --cov-report term-missing --cov-report html --cov=scrapd -m 'not integrations' tests (exited with code 2)
__________________________________________________________________________________ summary __________________________________________________________________________________
ERROR:   py37: commands failed