### PR TITLE
Ignore generation suffixes when parsing names

### DIFF
--- a/scrapd/cli/cli.py
+++ b/scrapd/cli/cli.py
@@ -32,13 +32,11 @@ __version__ = detect_from_metadata(APP_NAME)
     show_default=True,
 )
 @click.option('--from', 'from_', help='start date')
-@click.option('--gcontributors', help='comma separated list of contributors')
-@click.option('--gcredentials', type=click.Path(), help='path of the google credentials file')
 @click.option('--pages', default=-1, help='number pages to process')
 @click.option('--to', help='end date')
 @click.option('-v', '--verbose', count=True, help='adjust the log level')
 @click.pass_context
-def cli(ctx, format_, from_, gcontributors, gcredentials, pages, to, verbose):  # noqa: D403
+def cli(ctx, format_, from_, pages, to, verbose):  # noqa: D403
     """Retrieve APD's traffic fatality reports."""
     ctx.obj = {**ctx.params}
     ctx.auto_envvar_prefix = 'VZ'

--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -306,9 +306,13 @@ def parse_name(name):
     :return: a dictionary representing just the victim's first and last name
     :rtype: dict
     """
+    GENERATIONAL_TITLES = ['jr', 'jr.', 'sr', 'sr.']
     d = {}
     try:
-        d["last"] = name[-1].replace(',', '')
+        for i in range(1, len(name)):
+            d["last"] = name[-i].replace(',', '')
+            if d["last"].lower() not in GENERATIONAL_TITLES:
+                break
         d["first"] = name[0].replace(',', '')
     except (IndexError, TypeError):
         pass
@@ -742,7 +746,15 @@ async def fetch_and_parse(session, url):
 
 
 async def async_retrieve(pages=-1, from_=None, to=None):
-    """Retrieve fatality data."""
+    """
+    Retrieve fatality data.
+
+    :param str pages: number of pages to retrieve or -1 for all
+    :param str from_: the start date
+    :param str to: the end date
+    :return: the list of fatalities and the number of pages that were read.
+    :rtype: tuple
+    """
     res = {}
     page = 1
     has_entries = False

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -344,7 +344,11 @@ def test_parse_deceased_field_00(deceased, expected):
     }),
     (None, {
         'first': None,
-        'last': None
+        'last': None,
+    }),
+    (['Carlos', 'Cardenas', 'Jr.'], {
+        'first': 'Carlos',
+        'last': 'Cardenas',
     }),
 ))
 def test_parse_name(name, expected):


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

Generation suffixes like 'Jr.' or 'Sr.' were confused by the parser as
last names, which ended in incorrect data.

Drive-by:
* Remove unnecessary CLI flags.


<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [X] I have updated the documentation accordingly
-  [X] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes scrapd/scrapd#99