### PR TITLE
Add a wrapper task for nox sessions

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -14,9 +14,14 @@ Setup a local dev environment::
 
 Run the CI tasks locally ::
 
-  nox -s ci
+  inv nox ci
 
-Use `nox --list` and `inv --list` to see all the available targets.
+Use `inv --list`  and `inv nox` to see all the available targets.
+
+The `nox` tasks can be invoked by running  either:
+
+* `inv nox -s {task}`, for instance `inv nox -s test`
+* or directly with `nox -s test`
 
 Testing
 -------

--- a/tasks.py
+++ b/tasks.py
@@ -35,6 +35,15 @@ def clean_repo(c):
 
 
 @task
+def nox(c, s=''):
+    """Wrapper for the nox tasks (`inv nox list` for details)."""
+    if not s:
+        c.run('nox --list')
+    else:
+        c.run(f'nox -s {s}')
+
+
+@task
 def publish(c):
     """Publish the documentation."""
     c.run('./.circleci/publish.sh')


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- New feature (non-breaking change which adds functionality)
- Documentation

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

To allow developers to use only one tool, `invoke` instead of having to
switch between `inv` and `nox`, this patch adds a task wrapping the
`nox` commands.


<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->