### PR TITLE
Parametrize retries from the CLI

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -15,6 +15,11 @@ Available formats are:
   objects consisting of attribute–value pairs and array data types.
 * `Python`: displays the data in a way that is directly usable in Python.
 
+`attempts` defines the maximum number of attempts to parse a report before failing.
+
+`backoff` defines the initial wait time, in seconds, between 2 retries. This time is then multiplied by 2 for each retry
+(3s, then 6s, then 12s, etc.).
+
 `page` is a way to limit the number of results by specifying of many APD news pages to parse. For instance, using
 `--pages 5` means parsing the results until the URL https://austintexas.gov/department/news/296?page=4 is reached.
 The results of the specified page are included. In that case, the valid results of the 5th page will be included.

--- a/scrapd/cli/cli.py
+++ b/scrapd/cli/cli.py
@@ -22,6 +22,8 @@ __version__ = detect_from_metadata(APP_NAME)
 #   The arguments are used via the `self.args` dict of the `AbstractCommand` class.
 @click.version_option(version=__version__)
 @click.command()
+@click.option('-a', '--attempts', type=click.INT, default=3, help='number of attempts per report', show_default=True)
+@click.option('-b', '--backoff', type=click.INT, default=3, help='initial backoff time (second)', show_default=True)
 @click.option(
     '-f',
     '--format',
@@ -36,7 +38,7 @@ __version__ = detect_from_metadata(APP_NAME)
 @click.option('--to', help='end date')
 @click.option('-v', '--verbose', count=True, help='adjust the log level')
 @click.pass_context
-def cli(ctx, format_, from_, pages, to, verbose):  # noqa: D403
+def cli(ctx, attempt, backoff, format_, from_, pages, to, verbose):  # noqa: D403
     """Retrieve APD's traffic fatality reports."""
     ctx.obj = {**ctx.params}
     ctx.auto_envvar_prefix = 'VZ'
@@ -73,11 +75,14 @@ class Retrieve(AbstractCommand):
     def _execute(self):
         """Define the internal execution of the command."""
         # Collect the results.
-        results, _ = asyncio.run(apd.async_retrieve(
-            self.args['pages'],
-            self.args['from_'],
-            self.args['to'],
-        ))
+        results, _ = asyncio.run(
+            apd.async_retrieve(
+                self.args['pages'],
+                self.args['from_'],
+                self.args['to'],
+                self.args['attemps'],
+                self.args['backoff'],
+            ))
         result_count = len(results)
         logger.info(f'Total: {result_count}')
 

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -584,7 +584,7 @@ async def test_fetch_and_parse_00(empty_page):
 @asynctest.patch("scrapd.core.apd.fetch_detail_page", return_value='Not empty page')
 @pytest.mark.asyncio
 async def test_fetch_and_parse_01(page, mocker):
-    """Ensure an empty page raises an exception."""
+    """Ensure a page that cannot be parsed returns an exception."""
     mocker.patch("scrapd.core.apd.parse_page", return_value={})
     with pytest.raises(RetryError):
         apd.fetch_and_parse.retry.stop = stop_after_attempt(1)


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- New feature (non-breaking change which adds functionality)
- Code cleanup / Refactoring
- Documentation

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

Adds CLI flags to parametrize the number of attempts and the exponential
backoff multiplier.

Reconfigures the retryer to reraise the last exception instead of
raising `RetryError`, as well as changing the strategy to use a backoff
multiplier. The wait strategy will now be attempt_number * 3 seconds by
default.

The documentation was updated accordingly.

<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [X] I have updated the documentation accordingly
-  [X] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes scrapd/scrapd#149
Fixes scrapd/scrapd#151