### PR TITLE
Changing the parse_date_field function to parse to a date() instead o…

### DIFF
--- a/scrapd/core/apd.py
+++ b/scrapd/core/apd.py
@@ -545,9 +545,9 @@ def parse_page_content(detail_page, notes_parsed=False):
         d[Fields.CRASHES] = crash_str
 
     # Parse the `Date` field.
-    date_field_str = parse_date_field(normalized_detail_page)
-    if date_field_str:
-        d[Fields.DATE] = date_utils.parse_date(date_field_str)
+    date_field = parse_date_field(normalized_detail_page)
+    if date_field:
+        d[Fields.DATE] = date_field
 
     # Parse the `Deceased` field.
     deceased_field_str = parse_deceased_field(normalized_detail_page)
@@ -625,7 +625,7 @@ def parse_date_field(page):
     )
     date = match_pattern(page, date_pattern).replace('.', ' ')
     date = search_dates(date)
-    return date[0][1].strftime("%m/%d/%Y") if date else ''
+    return date[0][1].date() if date else None
 
 
 def parse_deceased_field(page):

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -677,8 +677,8 @@ def test_parse_time_field_00(input_, expected):
     ('>Date:  night Apr 1-2012</p>', date(2012, 4, 1)),
     ('>Date:  feb. 2 2018</p>', date(2018, 2, 2)),
     ('>Date:  10-1-17</p>', date(2017, 10, 1)),
-    ('>Date:  Morning of 2,2,19 </p>', date(2019, 2 ,2)),
-    ('>Date:  3/3/19</p>', date(2019,3, 3)),
+    ('>Date:  Morning of 2,2,19 </p>', date(2019, 2, 2)),
+    ('>Date:  3/3/19</p>', date(2019, 3, 3)),
     ('', None),
     ('>Date: Afternoon</p>', None),
 ))

--- a/tests/core/test_apd.py
+++ b/tests/core/test_apd.py
@@ -671,16 +671,16 @@ def test_parse_time_field_00(input_, expected):
 
 
 @pytest.mark.parametrize('input_,expected', (
-    ('<strong>Date:   </strong>April 18, 2019</p>', '04/18/2019'),
-    ('>Date:   </strong> Night of May 22 2019</p>', '05/22/2019'),
-    ('>Date:</span></strong>   Wednesday, Oct. 3, 2018</p>', '10/03/2018'),
-    ('>Date:  night Apr 1-2012</p>', '04/01/2012'),
-    ('>Date:  feb. 2 2018</p>', '02/02/2018'),
-    ('>Date:  10-1-17</p>', '10/01/2017'),
-    ('>Date:  Morning of 2,2,19 </p>', '02/02/2019'),
-    ('>Date:  3/3/19</p>', '03/03/2019'),
-    ('', ''),
-    ('>Date: Afternoon</p>', ''),
+    ('<strong>Date:   </strong>April 18, 2019</p>', date(2019, 4, 18)),
+    ('>Date:   </strong> Night of May 22 2019</p>', date(2019, 5, 22)),
+    ('>Date:</span></strong>   Wednesday, Oct. 3, 2018</p>', date(2018, 10, 3)),
+    ('>Date:  night Apr 1-2012</p>', date(2012, 4, 1)),
+    ('>Date:  feb. 2 2018</p>', date(2018, 2, 2)),
+    ('>Date:  10-1-17</p>', date(2017, 10, 1)),
+    ('>Date:  Morning of 2,2,19 </p>', date(2019, 2 ,2)),
+    ('>Date:  3/3/19</p>', date(2019,3, 3)),
+    ('', None),
+    ('>Date: Afternoon</p>', None),
 ))
 def test_parse_date_field_00(input_, expected):
     """Ensure a date field gets parsed correctly."""


### PR DESCRIPTION
…f a string

Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Code cleanup / Refactoring

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->
Change parse_date_field() to cast to date() object instead of string, and fix tests.

<!--
Motivation and Context
Why is this change required? What problem does it solve? -->
Unnecessary casting between obj and date

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->
Unit tests, integration tests, existing workflows

Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [x] I have ~written~ edited unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes: scrapd/scrapd#147
