### PR TITLE
add "born" as equivalent of "DOB" token

### DIFF
--- a/scrapd/core/person.py
+++ b/scrapd/core/person.py
@@ -152,7 +152,7 @@ def dob_search(split_deceased_field):
     :rtype: int
     """
     dob_index = -1
-    dob_tokens = [Fields.DOB, '(D.O.B', '(D.O.B.', '(D.O.B:', '(DOB', '(DOB:', 'D.O.B.', 'DOB:']
+    dob_tokens = [Fields.DOB, '(D.O.B', '(D.O.B.', '(D.O.B:', '(DOB', '(DOB:', 'D.O.B.', 'DOB:', 'born', 'Born']
     while dob_index < 0 and dob_tokens:
         dob_token = dob_tokens.pop()
         try:

--- a/tests/core/test_person.py
+++ b/tests/core/test_person.py
@@ -104,6 +104,16 @@ from scrapd.core.constant import Fields
             Fields.DOB: datetime.date(1999, 1, 1)
         },
     ),
+    (
+        'John Doe, Hispanic male, born 9-10-80',
+        {
+            Fields.FIRST_NAME: "John",
+            Fields.LAST_NAME: "Doe",
+            Fields.ETHNICITY: "Hispanic",
+            Fields.GENDER: "male",
+            Fields.DOB: datetime.date(1980, 9, 10)
+        },
+    )
 ))
 def test_process_deceased_field_00(deceased, expected):
     """Ensure a deceased field is parsed correctly."""

--- a/tests/core/test_person.py
+++ b/tests/core/test_person.py
@@ -7,114 +7,101 @@ from scrapd.core import person
 from scrapd.core.constant import Fields
 
 
-@pytest.mark.parametrize('deceased,expected', (
-    ("Rosbel “Rudy” Tamez, Hispanic male (D.O.B. 10-10-54)", {
-        Fields.FIRST_NAME: "Rosbel",
-        Fields.LAST_NAME: "Tamez",
+@pytest.mark.parametrize('deceased,expected', (("Rosbel “Rudy” Tamez, Hispanic male (D.O.B. 10-10-54)", {
+    Fields.FIRST_NAME: "Rosbel",
+    Fields.LAST_NAME: "Tamez",
+    Fields.ETHNICITY: "Hispanic",
+    Fields.GENDER: "male",
+    Fields.DOB: datetime.date(1954, 10, 10),
+}), ("Eva Marie Gonzales, W/F, DOB: 01-22-1961 (passenger)", {
+    Fields.FIRST_NAME: "Eva",
+    Fields.LAST_NAME: "Gonzales",
+    Fields.ETHNICITY: "White",
+    Fields.GENDER: 'female',
+    Fields.DOB: datetime.date(1961, 1, 22),
+}), (
+    'DOB: 01-01-99',
+    {
+        Fields.DOB: datetime.date(1999, 1, 1),
+    },
+), (
+    'Wing Cheung Chou | Asian male | 08/01/1949',
+    {
+        Fields.FIRST_NAME: "Wing",
+        Fields.LAST_NAME: "Chou",
+        Fields.ETHNICITY: "Asian",
+        Fields.GENDER: "male",
+        Fields.DOB: datetime.date(1949, 8, 1),
+    },
+), (
+    'Christopher M Peterson W/M 10-8-1981',
+    {
+        Fields.FIRST_NAME: "Christopher",
+        Fields.LAST_NAME: "Peterson",
+        Fields.ETHNICITY: "White",
+        Fields.GENDER: "male",
+        Fields.DOB: datetime.date(1981, 10, 8),
+    },
+), (
+    'Luis Angel Tinoco, Hispanic male (11-12-07',
+    {
+        Fields.FIRST_NAME: "Luis",
+        Fields.LAST_NAME: "Tinoco",
         Fields.ETHNICITY: "Hispanic",
         Fields.GENDER: "male",
-        Fields.DOB: datetime.date(1954, 10, 10),
-    }),
-    ("Eva Marie Gonzales, W/F, DOB: 01-22-1961 (passenger)", {
-        Fields.FIRST_NAME: "Eva",
-        Fields.LAST_NAME: "Gonzales",
+        Fields.DOB: datetime.date(2007, 11, 12)
+    },
+), (
+    'Ronnie Lee Hall, White male, 8-28-51',
+    {
+        Fields.FIRST_NAME: "Ronnie",
+        Fields.LAST_NAME: "Hall",
         Fields.ETHNICITY: "White",
-        Fields.GENDER: 'female',
-        Fields.DOB: datetime.date(1961, 1, 22),
-    }),
-    (
-        'DOB: 01-01-99',
-        {
-            Fields.DOB: datetime.date(1999, 1, 1),
-        },
-    ),
-    (
-        'Wing Cheung Chou | Asian male | 08/01/1949',
-        {
-            Fields.FIRST_NAME: "Wing",
-            Fields.LAST_NAME: "Chou",
-            Fields.ETHNICITY: "Asian",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(1949, 8, 1),
-        },
-    ),
-    (
-        'Christopher M Peterson W/M 10-8-1981',
-        {
-            Fields.FIRST_NAME: "Christopher",
-            Fields.LAST_NAME: "Peterson",
-            Fields.ETHNICITY: "White",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(1981, 10, 8),
-        },
-    ),
-    (
-        'Luis Angel Tinoco, Hispanic male (11-12-07',
-        {
-            Fields.FIRST_NAME: "Luis",
-            Fields.LAST_NAME: "Tinoco",
-            Fields.ETHNICITY: "Hispanic",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(2007, 11, 12)
-        },
-    ),
-    (
-        'Ronnie Lee Hall, White male, 8-28-51',
-        {
-            Fields.FIRST_NAME: "Ronnie",
-            Fields.LAST_NAME: "Hall",
-            Fields.ETHNICITY: "White",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(1951, 8, 28)
-        },
-    ),
-    (
-        'Hispanic male, 19 years of age',
-        {
-            Fields.ETHNICITY: "Hispanic",
-            Fields.GENDER: "male",
-            Fields.AGE: 19,
-        },
-    ),
-    (
-        'Patrick Leonard Ervin, Black male, D.O.B. August 30, 1966',
-        {
-            Fields.FIRST_NAME: "Patrick",
-            Fields.LAST_NAME: "Ervin",
-            Fields.ETHNICITY: "Black",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(1966, 8, 30)
-        },
-    ),
-    (
-        'Ernesto Gonzales Garcia, H/M, (DOB: 11/15/1977) ',
-        {
-            Fields.FIRST_NAME: "Ernesto",
-            Fields.LAST_NAME: "Garcia",
-            Fields.ETHNICITY: "Hispanic",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(1977, 11, 15)
-        },
-    ),
-    (
-        'B/F, DOB: 01-01-99',
-        {
-            Fields.ETHNICITY: "Black",
-            Fields.GENDER: "female",
-            Fields.DOB: datetime.date(1999, 1, 1)
-        },
-    ),
-    (
-        'John Doe, Hispanic male, born 9-10-80',
-        {
-            Fields.FIRST_NAME: "John",
-            Fields.LAST_NAME: "Doe",
-            Fields.ETHNICITY: "Hispanic",
-            Fields.GENDER: "male",
-            Fields.DOB: datetime.date(1980, 9, 10)
-        },
-    )
-))
+        Fields.GENDER: "male",
+        Fields.DOB: datetime.date(1951, 8, 28)
+    },
+), (
+    'Hispanic male, 19 years of age',
+    {
+        Fields.ETHNICITY: "Hispanic",
+        Fields.GENDER: "male",
+        Fields.AGE: 19,
+    },
+), (
+    'Patrick Leonard Ervin, Black male, D.O.B. August 30, 1966',
+    {
+        Fields.FIRST_NAME: "Patrick",
+        Fields.LAST_NAME: "Ervin",
+        Fields.ETHNICITY: "Black",
+        Fields.GENDER: "male",
+        Fields.DOB: datetime.date(1966, 8, 30)
+    },
+), (
+    'Ernesto Gonzales Garcia, H/M, (DOB: 11/15/1977) ',
+    {
+        Fields.FIRST_NAME: "Ernesto",
+        Fields.LAST_NAME: "Garcia",
+        Fields.ETHNICITY: "Hispanic",
+        Fields.GENDER: "male",
+        Fields.DOB: datetime.date(1977, 11, 15)
+    },
+), (
+    'B/F, DOB: 01-01-99',
+    {
+        Fields.ETHNICITY: "Black",
+        Fields.GENDER: "female",
+        Fields.DOB: datetime.date(1999, 1, 1)
+    },
+), (
+    'John Doe, Hispanic male, born 9-10-80',
+    {
+        Fields.FIRST_NAME: "John",
+        Fields.LAST_NAME: "Doe",
+        Fields.ETHNICITY: "Hispanic",
+        Fields.GENDER: "male",
+        Fields.DOB: datetime.date(1980, 9, 10)
+    },
+)))
 def test_process_deceased_field_00(deceased, expected):
     """Ensure a deceased field is parsed correctly."""
     d = person.process_deceased_field(deceased)


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->
Treats the word "born" in the Deceased field as the beginning of a "DOB" field (same as if the substring "DOB" had appeared instead of "born").

<!--
Motivation and Context
Why is this change required? What problem does it solve? -->
The parser was failing to assign the right text to the right fields because it couldn't tell where the DOB began.

<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->
I added a test case to test_person.test_process_deceased_field_00.

Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [x] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes: scrapd/scrapd#192
