### PR TITLE
Fix parsing with arrested field

### DIFF
--- a/scrapd/core/article.py
+++ b/scrapd/core/article.py
@@ -70,6 +70,8 @@ def parse_deceased_tag(deceased_tag_p):
             continue
         if "preliminary" in passage:
             break
+        if "Arrested:" in passage:
+            break
         deceased_field_str += passage.string
 
     return deceased_field_str.strip()

--- a/tests/core/test_article.py
+++ b/tests/core/test_article.py
@@ -108,6 +108,23 @@ deceased_tag_scenarios = [
         'expected': [],
         'id': 'empty',
     },
+    {
+        'input': '''
+            <strong>Deceased:</strong>&nbsp; &nbsp; Brianna Nicole Polzine, White female (10-28-93)<br>
+	        &nbsp;<br><strong>Arrested:</strong>&nbsp;&nbsp;&nbsp;&nbsp; Justin Dakota Ayers, White male (26 years of age)<br>
+	        &nbsp;&nbsp;<br>''',
+        'expected': ['Brianna Nicole Polzine, White female (10-28-93)'],
+        'id': 'with-arrested-00',
+    },
+    {
+        'input': '''
+            <strong>Deceased:</strong>&nbsp; &nbsp; &nbsp;Robert Copeland, White male, (D.O.B. 11-7-57)<br>
+	        &nbsp;<br><strong>Arrested:</strong> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Rafael Padilla, Hispanic male (28 years of age)<br>
+	        &nbsp;<br>
+        ''',
+        'expected': ['Robert Copeland, White male, (D.O.B. 11-7-57)'],
+        'id': 'with-arrested-01',
+    },
 ]
 
 


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

Articles containing an "Arrested" field were not parsed correctly and
the information about the person who got arrested was injected into the
deceased field.


<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [X] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes scrapd/scrapd#205