### PR TITLE
Fix incorrect deceased w/ arrested field parsing

### DIFF
--- a/scrapd/core/article.py
+++ b/scrapd/core/article.py
@@ -70,7 +70,7 @@ def parse_deceased_tag(deceased_tag_p):
             continue
         if "preliminary" in passage:
             break
-        if "Arrested:" in passage:
+        if "Arrested:" in passage.string:
             break
         deceased_field_str += passage.string
 

--- a/tests/core/test_article.py
+++ b/tests/core/test_article.py
@@ -125,6 +125,15 @@ deceased_tag_scenarios = [
         'expected': ['Robert Copeland, White male, (D.O.B. 11-7-57)'],
         'id': 'with-arrested-01',
     },
+    {
+        'input': '''
+            <strong>Deceased:&nbsp; </strong>&nbsp;&nbsp;&nbsp;Risean Deontay Lee Green | Black male | 10/16/1991<br>
+	        &nbsp;<br><strong>Arrested: &nbsp;</strong>&nbsp; &nbsp; Amanda Overman, White female, 30 years of age<br>
+	        &nbsp;<br>
+        ''',
+        'expected': ['Risean Deontay Lee Green | Black male | 10/16/1991'],
+        'id': 'with-arrested-02',
+    },
 ]
 
 

--- a/tests/features/retrieve.feature
+++ b/tests/features/retrieve.feature
@@ -11,5 +11,5 @@ Feature: Retrieve
     Examples:
       | format | from_date   | to_date     | crash_count | fatality_count |
       | csv    | Jan 15 2019 | Jan 18 2019 | 2           | 2              |
-      | json   | Jan 2018    | Dec 2018    | 72          | 73             |
+      | json   | Jan 2018    | Dec 2018    | 72          | 72             |
       | json   | Jan 15 2018 | Jan 18 2018 | 1           | 1              |


### PR DESCRIPTION
Types of changes
----------------
<!--
What types of changes does your code introduce?
Select all the choices that apply:
-->
- Bug fix (non-breaking change which fixes an issue)

Description
-----------
<!--
Describe your changes in detail.
Add a screenshot if applicable.
-->

Fixes the parsing logic to correctly ignore the `Arrested` field instead
of injected it into the middle name field.


<!--
Motivation and Context
Why is this change required? What problem does it solve? -->


<!--
How Has This Been Tested?
Add any information that could help the reviewer to validate the PR.
Please describe in detail how you tested your changes, include details
of your testing environment, and the tests you ran to see how your
change affects other areas of the code, etc.
-->


Checklist:
----------
<!--
Go over all the following points, and put an `x` in all the boxes that
apply. If you're unsure about any of these, don't hesitate to ask.
We're here to help!
-->

-  [] I have updated the documentation accordingly
-  [X] I have written unit tests

<!--
Place the URL of the issue here it this PR fixes an existing issue.
Use either the *FULL* URL (preferred) or the `Username/Repository#`
syntax.
-->

Fixes scrapd/scrapd#226